### PR TITLE
📖 [Docs]: README pages now use the standard module landing-page format

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,3 @@ This repository is currently a placeholder. The module source still contains sca
 ## Documentation
 
 When this module is implemented, command details should live in PowerShell help and generated documentation rather than being duplicated in this README.
-
-## Contributing
-
-Issues and pull requests are welcome when implementation work begins.

--- a/README.md
+++ b/README.md
@@ -1,69 +1,11 @@
-# {{ NAME }}
+# Domeneshop
 
-{{ DESCRIPTION }}
+Domeneshop is intended to be a PowerShell module for interacting with the Domeneshop APIs.
 
-## Prerequisites
+## Status
 
-This uses the following external resources:
-- The [PSModule framework](https://github.com/PSModule/Process-PSModule) for building, testing and publishing the module.
-
-## Installation
-
-To install the module from the PowerShell Gallery, you can use the following command:
-
-```powershell
-Install-PSResource -Name {{ NAME }}
-Import-Module -Name {{ NAME }}
-```
-
-## Usage
-
-Here is a list of example that are typical use cases for the module.
-
-### Example 1: Greet an entity
-
-Provide examples for typical commands that a user would like to do with the module.
-
-```powershell
-Greet-Entity -Name 'World'
-Hello, World!
-```
-
-### Example 2
-
-Provide examples for typical commands that a user would like to do with the module.
-
-```powershell
-Import-Module -Name PSModuleTemplate
-```
-
-### Find more examples
-
-To find more examples of how to use the module, please refer to the [examples](examples) folder.
-
-Alternatively, you can use the Get-Command -Module 'This module' to find more commands that are available in the module.
-To find examples of each of the commands you can use Get-Help -Examples 'CommandName'.
-
-## Documentation
-
-Link to further documentation if available, or describe where in the repository users can find more detailed documentation about
-the module's functions and features.
+This repository is currently a placeholder. The module source still contains scaffold code, so there are no supported commands or usage examples to document yet.
 
 ## Contributing
 
-Coder or not, you can contribute to the project! We welcome all contributions.
-
-### For Users
-
-If you don't code, you still sit on valuable information that can make this project even better. If you experience that the
-product does unexpected things, throw errors or is missing functionality, you can help by submitting bugs and feature requests.
-Please see the issues tab on this project and submit a new issue that matches your needs.
-
-### For Developers
-
-If you do code, we'd love to have your contributions. Please read the [Contribution guidelines](CONTRIBUTING.md) for more information.
-You can either help by picking up an existing issue or submit a new one if you have an idea for a new feature or improvement.
-
-## Acknowledgements
-
-Here is a list of people and projects that helped this project in some way.
+Issues and pull requests are welcome when implementation work begins.

--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ This repository is currently a placeholder. The module source still contains sca
 
 ## Documentation
 
-When this module is implemented, command details should live in PowerShell help and generated documentation rather than being duplicated in this README.
+Documentation is not published yet because this module is still a placeholder. Once the module is implemented, command details will live in PowerShell help and generated documentation rather than being duplicated in this README.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Domeneshop is intended to be a PowerShell module for interacting with the Domene
 
 This repository is currently a placeholder. The module source still contains scaffold code, so there are no supported commands or usage examples to document yet.
 
+## Documentation
+
+When this module is implemented, command details should live in PowerShell help and generated documentation rather than being duplicated in this README.
+
 ## Contributing
 
 Issues and pull requests are welcome when implementation work begins.


### PR DESCRIPTION
The `Domeneshop` README now follows the standard PSModule landing-page format.

Because this module is still a scaffold-only placeholder, the README keeps its minimal placeholder shape (title, one-line description, `## Status`, `## Documentation`) and does not show any usage examples for commands that do not exist yet. The `## Contributing` section has been removed so contribution guidance lives in the shared community/process files rather than being duplicated per repository.

## What changed

- Removed the `## Contributing` section from `README.md`.
- Kept the placeholder shape and status notice intact (no invented commands or usage examples).

## Scope

- `README.md` only.
