### PR TITLE
🩹 [Patch]: Centralized public help validation restored

### DIFF
--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -27,6 +27,6 @@ permissions:
 
 jobs:
   Process-PSModule:
-    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@fb1bdb8fefd243292f779d2a856a38db6fe6daf4 # v6.1.13
+    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@b11b310e461f08ee99055b0827ef7909dea7110a # v6.1.14
     secrets:
       APIKEY: ${{ secrets.APIKEY }}


### PR DESCRIPTION
Domeneshop validation again covers the canonical public help-link contract after the repository-local duplicate tests were removed.

## Fixed: Public help links remain centrally validated

The shared module workflow now uses Process-PSModule v6.1.14, which validates canonical public help links for both grouped and ungrouped public functions, including first-link ordering and the required trailing slash.

---
<details>
<summary>Technical details</summary>

- Replaces the immutable Process-PSModule v6.1.13 workflow SHA with the immutable v6.1.14 release SHA.
- Activates the centralized validation introduced by Process-PSModule PR #420, closing the dependency gap after Domeneshop PR #17 removed repository-local public-help, module-requirement, and test-layout tests.
- No source, test, or help-link content changes are included.

</details>

<details>
<summary>Relevant issues (or links)</summary>

- PSModule/Process-PSModule#420
- PSModule/Domeneshop#17

</details>